### PR TITLE
Fix grafana

### DIFF
--- a/modules/oci/services/grafana.scm
+++ b/modules/oci/services/grafana.scm
@@ -310,9 +310,13 @@ to \"host\" the @code{port} field will be ignored."))
               (if (and password-file (maybe-value-set? password-file))
                   '(sops-secrets)
                   '()))
-             ;; HACK: required to map container user to `oci-container' host
-             ;; user.
-             (extra-arguments '("--userns=keep-id:uid=1001"))
+             (extra-arguments (if (oci-volume-configuration? datadir)
+                                  '()
+                                  ;; NOTE: map container user to host user. This
+                                  ;; ensures that the container user has the
+                                  ;; correct permisions to operate on the
+                                  ;; volume.
+                                  '("--userns=keep-id:uid=1001")))
              (image image)
              (ports
               `((,port . "3000")))

--- a/modules/oci/services/grafana.scm
+++ b/modules/oci/services/grafana.scm
@@ -95,24 +95,6 @@
    (boolean #f)
    "The image to use for the OCI backed Shepherd service."))
 
-(define (gf-serialize-grafana-smtp-configuration field-name value)
-  (define password-file (grafana-smtp-configuration-password-file value))
-  (define password (grafana-smtp-configuration-password value))
-  (define serialized-secret
-    (if (maybe-value-set? password-file)
-        (string-append "password = $__file{"
-                       %grafana-secrets-directory "/"
-                       (sops-secret->file-name password-file)
-                       "}\n")
-        (if (string-null? password)
-            ""
-            (string-append "password = " password "\n"))))
-  #~(string-append
-     "[smtp]\n"
-     #$(serialize-configuration
-        value grafana-smtp-configuration-fields)
-     #$serialized-secret))
-
 (define-maybe sops-secret)
 
 (define-configuration grafana-smtp-configuration
@@ -137,6 +119,24 @@ will read the SMTP password."
   (from-address
    (string "alert@example.org")
    "The sender of the email alerts Grafana will send."))
+
+(define (gf-serialize-grafana-smtp-configuration field-name value)
+  (define password-file (grafana-smtp-configuration-password-file value))
+  (define password (grafana-smtp-configuration-password value))
+  (define serialized-secret
+    (if (maybe-value-set? password-file)
+        (string-append "password = $__file{"
+                       %grafana-secrets-directory "/"
+                       (sops-secret->file-name password-file)
+                       "}\n")
+        (if (string-null? password)
+            ""
+            (string-append "password = " password "\n"))))
+  #~(string-append
+     "[smtp]\n"
+     #$(serialize-configuration
+        value grafana-smtp-configuration-fields)
+     #$serialized-secret))
 
 (define (gf-serialize-grafana-configuration configuration)
   (mixed-text-file

--- a/modules/oci/services/grafana.scm
+++ b/modules/oci/services/grafana.scm
@@ -290,7 +290,6 @@ to \"host\" the @code{port} field will be ignored."))
               (and (grafana-configuration? maybe-record)
                    (grafana-smtp-configuration-password-file
                     (grafana-configuration-smtp maybe-record)))))
-           (uid (number->string (passwd:uid (getpwnam "oci-container"))))
            (network
             (oci-grafana-configuration-network config))
            (image
@@ -311,13 +310,9 @@ to \"host\" the @code{port} field will be ignored."))
               (if (and password-file (maybe-value-set? password-file))
                   '(sops-secrets)
                   '()))
-             (container-user (if (eq? 'podman runtime)
-                                 uid
-                                 %unset-value))
              ;; HACK: required to map container user to `oci-container' host
              ;; user.
-             (extra-arguments (list "--userns"
-                                    (string-append "keep-id:uid=" uid)))
+             (extra-arguments '("--userns=keep-id:uid=1001"))
              (image image)
              (ports
               `((,port . "3000")))


### PR DESCRIPTION
With PR #21, I introduced a few bugs that I'm addressing here.

This PR corrects:
- Incorrect expansion of all branches of Grafana's smtp configuration serializer.
- Macro expansion error due to definition order of Grafana's smtp configuration serializer.
- Inability to reconfigure if the oci-container user does not exist